### PR TITLE
fix cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,7 @@ name = "stb_image"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 
-build = "make -f makefile.cargo"
+build = "build.rs"
+
+[build-dependencies]
+gcc = "0.1.6"


### PR DESCRIPTION
Cargo failed to build because Cargo.toml still referenced the Makefile. Additionally the build dependency on the gcc crate was missing.
